### PR TITLE
Support graphical apps inside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM node:10-stretch
 
+RUN    apt-get update && apt-get install -y \
+    dirmngr \
+    gnupg \
+    --no-install-recommends \
+    mousepad \
+    libgl1-mesa-dri \
+    libgl1-mesa-glx \
+    xdg-utils \
+    --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
 # versions
 ARG ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
 ARG ANDROID_SYSTEM_PACKAGE="android-28"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Toolchain versions:
 
 `$ docker build -t nativescript .` <-- this might take a while
 
-`$ docker run -i -t nativescript /bin/bash`
+Authorize the Docker container to access your X environment (The need for this has been introduced by Wayland. See: https://wiki.archlinux.org/index.php/Running_GUI_applications_as_root#Wayland).
+
+`$ xhost local:`
+
+`$ docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY nativescript /bin/bash`
 
 
 Optionally see if it's working:


### PR DESCRIPTION
We should remove the test mousepad application from the container before resolving this pull request.